### PR TITLE
Implement httppost

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ lazy val log4catsVersion            = "2.5.0"
 lazy val circeVersion               = "0.14.0"
 lazy val fs2Version                 = "3.6.1"
 lazy val http4sVersion              = "0.23.18"
+lazy val fs2KafkaVersion            = "2.5.0"
+lazy val kafkaVersion               = "3.4.0"
 
 lazy val root = (project in file("."))
   .settings(
@@ -27,6 +29,7 @@ lazy val root = (project in file("."))
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-fs2" % circeVersion,
-      "org.http4s" %% "http4s-ember-client" % http4sVersion
+      "org.http4s" %% "http4s-ember-client" % http4sVersion,
+      "org.apache.kafka" % "kafka-clients" % kafkaVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val root = (project in file("."))
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
+      "io.circe" %% "circe-parser" % circeVersion,
       "io.circe" %% "circe-fs2" % circeVersion,
       "org.http4s" %% "http4s-ember-client" % http4sVersion
     )

--- a/src/main/resources/file1.txt
+++ b/src/main/resources/file1.txt
@@ -1,0 +1,3 @@
+asdf
+asd
+sd

--- a/src/main/resources/watcher-config.json
+++ b/src/main/resources/watcher-config.json
@@ -1,0 +1,19 @@
+{
+  "fileConfigs": [
+    {
+      "file": "src/main/resources/file1.txt",
+      "interval": "1s",
+      "destination": {
+        "type": "http",
+        "uri": "https://example.com/api"
+      }
+    },
+    {
+      "file": "src/main/resources/file2.txt",
+      "interval": "2s",
+      "destination": {
+        "type": "console"
+      }
+    }
+  ]
+}

--- a/src/main/scala/com/mungos/filewatcher/FileWatcherApp.scala
+++ b/src/main/scala/com/mungos/filewatcher/FileWatcherApp.scala
@@ -5,11 +5,9 @@ import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import cats.implicits.*
 import cats.syntax.all.*
-import com.mungos.filewatcher.io.FileReader
-import com.mungos.filewatcher.modules.{FileProcessor, FileScheduler}
+import com.mungos.filewatcher.modules.{FileProcessor, FileReader, FileScheduler}
 import com.mungos.filewatcher.utils.effectfulUtils.*
 import fs2.Stream
-import fs2.concurrent.SignallingRef
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
@@ -19,17 +17,13 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.*
 
 object FileWatcherApp extends IOApp.Simple {
-
   given logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
-  val config: WatcherConfig = WatcherConfig(
-    List(
-      FileConfig(file = "src\\main\\scala\\com\\mungos\\filewatcher\\WatcherConfig.scala", interval = 1.second),
-      FileConfig(file = "src\\main\\scala\\com\\mungos\\filewatcher\\FileWatcherApp.scala", interval = 2.second),
-    ))
-
+  import com.mungos.filewatcher.utils.ConfigUtils._
   override def run: IO[Unit] = for
     raf <- Ref.of[IO, Map[String, Long]](Map.empty)
+    json <- readConfigFile("src/main/resources/watcher-config.json")
+    config <- decodeWatcherConfig(json)
     _ <- config.fileConfigs.parTraverse { fileConfig =>
       FileScheduler.make[IO](FileProcessor.make[IO]()).processFile(fileConfig, KeyValueRef[IO, String, Long](raf))
     }

--- a/src/main/scala/com/mungos/filewatcher/FileWatcherApp.scala
+++ b/src/main/scala/com/mungos/filewatcher/FileWatcherApp.scala
@@ -5,8 +5,8 @@ import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import cats.implicits.*
 import cats.syntax.all.*
-import com.mungos.filewatcher.modules.{FileProcessor, FileReader, FileScheduler}
-import com.mungos.filewatcher.utils.effectfulUtils.*
+import com.mungos.filewatcher.modules.{FileProcessor, FileReader, FileScheduler, HttpClientPool, KafkaMessageSenderFactory, KafkaMessageSenderPool}
+import com.mungos.filewatcher.utils.effectfulUtils.{KeyValueRef, *}
 import fs2.Stream
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -16,16 +16,27 @@ import java.util.concurrent.Executors
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.*
 
-object FileWatcherApp extends IOApp.Simple {
+object FileWatcherApp extends IOApp {
   given logger: Logger[IO] = Slf4jLogger.getLogger[IO]
 
-  import com.mungos.filewatcher.utils.ConfigUtils._
-  override def run: IO[Unit] = for
-    raf <- Ref.of[IO, Map[String, Long]](Map.empty)
-    json <- readConfigFile("src/main/resources/watcher-config.json")
-    config <- decodeWatcherConfig(json)
-    _ <- config.fileConfigs.parTraverse { fileConfig =>
-      FileScheduler.make[IO](FileProcessor.make[IO]()).processFile(fileConfig, KeyValueRef[IO, String, Long](raf))
-    }
-  yield ()
+  import com.mungos.filewatcher.utils.configUtils._
+  override def run(args: List[String]): IO[ExitCode] = {
+    val configFilename = args.headOption.getOrElse("src/main/resources/watcher-config.json")
+    val fixedPoolSize = 10
+
+    val kafkaMessageSenderFactory = KafkaMessageSenderFactory.make[IO]
+    val fileProcessor = FileProcessor.make[IO]()
+
+    for
+      raf <- Ref.of[IO, Map[String, Long]](Map.empty)
+      json <- readConfigFile(configFilename)
+      config <- decodeWatcherConfig(json)
+      kafkaMessageSenderPool <- KafkaMessageSenderPool.make[IO](fixedPoolSize, kafkaMessageSenderFactory)
+      httpPostClientPool <- HttpClientPool.make[IO](fixedPoolSize)
+      _ <- config.fileConfigs.parTraverse { fileConfig => {
+          FileScheduler.make[IO](fileProcessor).processFile(fileConfig, KeyValueRef[IO, String, Long](raf), httpPostClientPool, kafkaMessageSenderPool)
+        }
+      }
+    yield ExitCode.Success
+  }
 }

--- a/src/main/scala/com/mungos/filewatcher/WatcherConfig.scala
+++ b/src/main/scala/com/mungos/filewatcher/WatcherConfig.scala
@@ -1,5 +1,12 @@
 package com.mungos.filewatcher
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder, HCursor, Json, DecodingFailure}
+import io.circe.syntax.*
+import io.circe.parser.*
+import fs2.concurrent.Topic
+
+import java.util.Properties
 import scala.concurrent.duration.FiniteDuration
 
 case class WatcherConfig (
@@ -7,5 +14,28 @@ case class WatcherConfig (
 )
 case class FileConfig (
   file: String,
-  interval: FiniteDuration
+  interval: FiniteDuration,
+  destination: Destination
 )
+
+sealed trait Destination
+object Console extends Destination
+case class HttpDestination(uri: String) extends Destination
+case class KafkaDestination(brokers: String, topic: String) extends Destination
+
+enum DestinationType:
+  case HTTP, KAFKA
+
+object Destination:
+  given Decoder[Destination] with
+    def apply(cursor: HCursor): Decoder.Result[Destination] =
+      cursor.keys.map(_.toVector) match {
+        case Some(Vector("uri")) => cursor.as[HttpDestination]
+        case Some(Vector("brokers", "topic")) => cursor.as[KafkaDestination]
+        case _ => Left(DecodingFailure("Invalid Destination JSON", cursor.history))
+      }
+
+object HttpDestination:
+  given Decoder[HttpDestination] = deriveDecoder
+object KafkaDestination:
+  given Decoder[KafkaDestination] = deriveDecoder

--- a/src/main/scala/com/mungos/filewatcher/modules/FileProcessor.scala
+++ b/src/main/scala/com/mungos/filewatcher/modules/FileProcessor.scala
@@ -5,7 +5,6 @@ import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import cats.implicits.*
 import cats.syntax.all.*
-import com.mungos.filewatcher.io.FileReader
 import com.mungos.filewatcher.utils.effectfulUtils.KeyValueRef
 import com.mungos.filewatcher.{FileConfig, FileWatcherApp}
 import fs2.Stream

--- a/src/main/scala/com/mungos/filewatcher/modules/FileProcessor.scala
+++ b/src/main/scala/com/mungos/filewatcher/modules/FileProcessor.scala
@@ -6,16 +6,18 @@ import cats.effect.unsafe.implicits.global
 import cats.implicits.*
 import cats.syntax.all.*
 import com.mungos.filewatcher.utils.effectfulUtils.KeyValueRef
-import com.mungos.filewatcher.{FileConfig, FileWatcherApp}
+import com.mungos.filewatcher.{ConsoleDestination, FileConfig, FileWatcherApp, HttpDestination, KafkaDestination}
 import fs2.Stream
+import fs2.text.utf8
 import org.typelevel.log4cats.Logger
+import org.http4s.*
 
 import java.io.File
 import scala.concurrent.duration.FiniteDuration
 
 trait FileProcessor[F[_]]:
   def getNewLinesFromFile(fileReader: FileReader[F], prevLength: Long): F[List[String]]
-  def processingInterval(currentTime: FiniteDuration, fileConfig: FileConfig, filePositionMap: KeyValueRef[F, String, Long]): F[Unit]
+  def processingInterval(currentTime: FiniteDuration, fileConfig: FileConfig, filePositionMap: KeyValueRef[F, String, Long], httpClientPool: HttpClientPool[F], kafkaMessageSenderPool: KafkaMessageSenderPool[F]): F[Unit]
 
 object FileProcessor {
   def make[F[_]: Sync: Logger](): FileProcessor[F] = new FileProcessor[F]:
@@ -25,13 +27,37 @@ object FileProcessor {
         lines <- fileReader.lines
       } yield lines
 
-    override def processingInterval(currentTime: FiniteDuration, fileConfig: FileConfig, filePositionMap: KeyValueRef[F, String, Long]): F[Unit] = for {
-      pos <- filePositionMap.get(fileConfig.file)
-      file <- Sync[F].delay(new File(fileConfig.file))
-      newLines <- FileReader.make[F](file).use { fileReader =>
-        getNewLinesFromFile(fileReader, pos.getOrElse(0L))
-      }
-      _ <- Logger[F].info(s"[$currentTime] ${newLines.mkString(",")}")
-      _ <- filePositionMap.put(fileConfig.file, file.length())
-    } yield ()
+    override def processingInterval(currentTime: FiniteDuration,
+      fileConfig: FileConfig,
+      filePositionMap: KeyValueRef[F, String, Long],
+      httpClientPool: HttpClientPool[F],
+      kafkaMessageSenderPool: KafkaMessageSenderPool[F]): F[Unit] =
+      for {
+        pos <- filePositionMap.get(fileConfig.file)
+        file <- Sync[F].delay(new File(fileConfig.file))
+        newLines <- FileReader.make[F](file).use { fileReader =>
+          getNewLinesFromFile(fileReader, pos.getOrElse(0L))
+        }
+        _ <- fileConfig.destination match {
+          case HttpDestination(uri) =>
+            for {
+              client <- httpClientPool.get
+              _ <- Logger[F].info(s"Sending new lines from ${fileConfig.file} to ${uri}")
+              _ <- client.post(Uri.unsafeFromString(uri), newLines.mkString(","))
+              _ <- httpClientPool.release(client)
+            } yield ()
+
+          case KafkaDestination(brokers, topic) =>
+            for {
+              producer <- kafkaMessageSenderPool.get(brokers)
+              _ <- producer.send(topic, fileConfig.file, newLines.mkString("\n"))
+              _ <- kafkaMessageSenderPool.release(brokers, producer)
+            } yield ()
+
+          case ConsoleDestination =>
+            Logger[F].info(newLines.mkString("\n"))
+        }
+        _ <- Logger[F].info(s"[$currentTime] ${newLines.mkString(",")}")
+        _ <- filePositionMap.put(fileConfig.file, file.length())
+      } yield ()
 }

--- a/src/main/scala/com/mungos/filewatcher/modules/FileReader.scala
+++ b/src/main/scala/com/mungos/filewatcher/modules/FileReader.scala
@@ -1,4 +1,4 @@
-package com.mungos.filewatcher.io
+package com.mungos.filewatcher.modules
 
 import cats.effect.kernel.Sync
 import cats.effect.{IO, Resource}

--- a/src/main/scala/com/mungos/filewatcher/modules/FileScheduler.scala
+++ b/src/main/scala/com/mungos/filewatcher/modules/FileScheduler.scala
@@ -7,14 +7,14 @@ import fs2.Stream
 import org.typelevel.log4cats.Logger
 
 trait FileScheduler[F[_]]:
-  def processFile(fileConfig: FileConfig, filePositionMap: KeyValueRef[F, String, Long]): F[Unit]
+  def processFile(fileConfig: FileConfig, filePositionMap: KeyValueRef[F, String, Long], httpClientPool: HttpClientPool[F], kafkaMessageSenderPool: KafkaMessageSenderPool[F]): F[Unit]
 
 
 object FileScheduler:
   def make[F[_]: Temporal : Sync : Logger](fileProcessor: FileProcessor[F]): FileScheduler[F] = new FileScheduler[F]:
-    override def processFile(fileConfig: FileConfig, filePositionMap: KeyValueRef[F, String, Long]): F[Unit] = Stream
+    override def processFile(fileConfig: FileConfig, filePositionMap: KeyValueRef[F, String, Long], httpClientPool: HttpClientPool[F], kafkaMessageSenderPool: KafkaMessageSenderPool[F]): F[Unit] = Stream
       .awakeEvery[F](fileConfig.interval)
       .evalMap { currentTime =>
-        fileProcessor.processingInterval(currentTime, fileConfig, filePositionMap)
+        fileProcessor.processingInterval(currentTime, fileConfig, filePositionMap, httpClientPool, kafkaMessageSenderPool)
       }.compile
       .drain

--- a/src/main/scala/com/mungos/filewatcher/modules/HttpPostClient.scala
+++ b/src/main/scala/com/mungos/filewatcher/modules/HttpPostClient.scala
@@ -6,11 +6,11 @@ import org.http4s.Method.POST
 import org.http4s.client.Client
 
 trait HttpPostClient[F[_]]:
-  def post(uri: Uri, body: EntityBody[F], headers: Headers = Headers.empty): F[Response[F]]
+  def post(uri: Uri, body: String, headers: Headers = Headers.empty): F[String]
 
 object HttpPostClient {
   def make[F[_]: Async](client: Client[F]): HttpPostClient[F] = new HttpPostClient[F]:
-    override def post(uri: Uri, body: EntityBody[F], headers: Headers): F[Response[F]] =
+    override def post(uri: Uri, body: String, headers: Headers): F[String] =
       val request = Request[F](POST, uri, headers = headers).withEntity(body)
-      client.run(request).use(response => Async[F].pure(response))
+      client.expect[String](request)
 }

--- a/src/main/scala/com/mungos/filewatcher/modules/KafkaMessageSender.scala
+++ b/src/main/scala/com/mungos/filewatcher/modules/KafkaMessageSender.scala
@@ -1,0 +1,43 @@
+package com.mungos.filewatcher.modules
+
+import cats.effect.Async
+import org.apache.kafka.common.serialization.StringSerializer
+import cats.syntax.functor.*
+import org.typelevel.log4cats.Logger
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord, RecordMetadata}
+
+import java.util.Properties
+import java.util.concurrent.{CompletableFuture, Future}
+
+trait KafkaMessageSender[F[_]]:
+	def send(topic: String, key: String, value: String): F[Unit]
+object KafkaMessageSender {
+	def make[F[_]: Async](producer: KafkaProducer[String, String]): KafkaMessageSender[F] = new KafkaMessageSender[F]:
+		override def send(topic: String, key: String, value: String): F[Unit] = {
+			val record = new ProducerRecord[String, String](topic, key, value)
+			val javaFuture: Future[RecordMetadata] = producer.send(record)
+			val completableFuture: CompletableFuture[Void] = CompletableFuture.supplyAsync(() => javaFuture.get()).thenAccept(_ => ())
+			Async[F].fromCompletableFuture(Async[F].delay(completableFuture)).void
+		}
+}
+
+type Brokers = String
+
+trait KafkaMessageSenderFactory[F[_]]:
+	def create(brokers: String): KafkaMessageSender[F]
+
+object KafkaMessageSenderFactory:
+	def make[F[_] : Async : Logger]: KafkaMessageSenderFactory[F] = new KafkaMessageSenderFactory[F] {
+		override def create(brokers: Brokers): KafkaMessageSender[F] = {
+			val producerProps = new Properties()
+			producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+			producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
+			producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer])
+
+			val producer = new KafkaProducer[String, String](producerProps)
+
+			KafkaMessageSender.make[F](producer)
+		}
+	}
+
+	def default[F[_] : Async : Logger]: KafkaMessageSenderFactory[F] = make[F]

--- a/src/main/scala/com/mungos/filewatcher/modules/KafkaMessageSenderPool.scala
+++ b/src/main/scala/com/mungos/filewatcher/modules/KafkaMessageSenderPool.scala
@@ -1,0 +1,59 @@
+package com.mungos.filewatcher.modules
+
+import cats.effect.*
+import cats.syntax.all.*
+import cats.effect.std.Queue
+import com.mungos.filewatcher.utils.effectfulUtils.KeyValueRef
+import org.typelevel.log4cats.Logger
+
+/**
+ * KafkaMessageSenderPool is a trait representing a pool of KafkaMessageSender instances.
+ * This pool is used to manage and reuse KafkaMessageSender instances based on the brokers string.
+ */
+trait KafkaMessageSenderPool[F[_]]:
+	/**
+	 * Get a KafkaMessageSender instance for the given brokers.
+	 * If a KafkaMessageSender instance for the brokers already exists, it will be reused.
+	 * Otherwise, a new instance will be created and added to the pool.
+	 *
+	 * @param brokers The brokers string used to connect to the Kafka cluster.
+	 * @return A KafkaMessageSender instance for the specified brokers.
+	 */
+	def get(brokers: String): F[KafkaMessageSender[F]]
+	def release(brokers: String, sender: KafkaMessageSender[F]): F[Unit]
+	def size: F[Int]
+object KafkaMessageSenderPool {
+	def make[F[_] : Async : Logger](
+		poolSize: Int,
+		kafkaMessageSenderFactory: KafkaMessageSenderFactory[F]
+	): F[KafkaMessageSenderPool[F]] =
+		for {
+			pool <- Ref.of[F, Map[String, Queue[F, KafkaMessageSender[F]]]](Map.empty)
+			keyValueRef = KeyValueRef[F, String, Queue[F, KafkaMessageSender[F]]](pool)
+		} yield new KafkaMessageSenderPool[F]:
+			override def get(brokers: String): F[KafkaMessageSender[F]] =
+				keyValueRef.get(brokers).flatMap {
+					case Some(queue) =>
+						Logger[F].info(s"Reusing KafkaMessageSender for brokers: $brokers") *>
+							queue.take
+					case None =>
+						for {
+							_ <- Logger[F].info(s"Creating KafkaMessageSender queue for brokers: $brokers")
+							newQueue <- Queue.bounded[F, KafkaMessageSender[F]](poolSize)
+							_ <- keyValueRef.put(brokers, newQueue)
+							sender = kafkaMessageSenderFactory.create(brokers)
+							_ <- newQueue.offer(sender)
+						} yield sender
+				}
+
+			override def release(brokers: String, sender: KafkaMessageSender[F]): F[Unit] =
+				keyValueRef.get(brokers).flatMap {
+					case Some(queue) =>
+						Logger[F].info(s"Releasing KafkaMessageSender for brokers: $brokers") *>
+							queue.offer(sender)
+					case None =>
+						Logger[F].error(s"Attempting to release a KafkaMessageSender for unknown brokers: $brokers")
+				}
+
+			override def size: F[Int] = keyValueRef.ref.get.map(_.size)
+}

--- a/src/main/scala/com/mungos/filewatcher/utils/ConfigUtils.scala
+++ b/src/main/scala/com/mungos/filewatcher/utils/ConfigUtils.scala
@@ -1,0 +1,38 @@
+package com.mungos.filewatcher.utils
+
+import cats.effect.IO
+import com.mungos.filewatcher.WatcherConfig
+import fs2.concurrent.SignallingRef
+import fs2.io.file.{Files, Flag, Flags, Path}
+import fs2.text.utf8
+import io.circe.{Decoder, DecodingFailure}
+import io.circe.generic.auto.*
+import io.circe.parser.*
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+object ConfigUtils:
+  def readConfigFile(file: String): IO[String] = {
+    Files[IO]
+      .readAll(Path(file), 4096, Flags.Read)
+      .through(utf8.decode)
+      .compile
+      .string
+  }
+
+  def decodeWatcherConfig(json: String): IO[WatcherConfig] = {
+    given Decoder[FiniteDuration] with
+      def apply(c: io.circe.HCursor): Decoder.Result[FiniteDuration] = {
+        c.as[String].flatMap { durationStr =>
+          Duration(durationStr) match {
+            case finiteDuration: FiniteDuration => Right(finiteDuration)
+            case _ => Left(DecodingFailure("Invalid duration format", c.history))
+          }
+        }
+      }
+
+    decode[WatcherConfig](json) match {
+      case Right(config) => IO.pure(config)
+      case Left(error) => IO.raiseError(new RuntimeException(s"Error decoding JSON: $error"))
+    }
+  }

--- a/src/main/scala/com/mungos/filewatcher/utils/configUtils.scala
+++ b/src/main/scala/com/mungos/filewatcher/utils/configUtils.scala
@@ -11,7 +11,7 @@ import io.circe.parser.*
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
-object ConfigUtils:
+object configUtils:
   def readConfigFile(file: String): IO[String] = {
     Files[IO]
       .readAll(Path(file), 4096, Flags.Read)

--- a/src/test/scala/com/mungos/filewatcher/modules/KafkaMessageSenderPoolSpec.scala
+++ b/src/test/scala/com/mungos/filewatcher/modules/KafkaMessageSenderPoolSpec.scala
@@ -1,0 +1,44 @@
+package com.mungos.filewatcher.modules
+
+import cats.effect._
+import cats.syntax.all._
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import scala.concurrent.duration._
+
+class KafkaMessageSenderPoolSpec extends AsyncFunSuite with Matchers with AsyncIOSpec {
+
+	given logger: Logger[IO] = Slf4jLogger.getLogger[IO]
+	// Mock KafkaMessageSenderFactory
+	val mockKafkaMessageSenderFactory: KafkaMessageSenderFactory[IO] = new KafkaMessageSenderFactory[IO] {
+		override def create(brokers: String): KafkaMessageSender[IO] =
+			new KafkaMessageSender[IO] {
+				override def send(topic: String, key: String, value: String): IO[Unit] = IO.unit
+			}
+	}
+
+	test("KafkaMessageSenderPool should correctly create, reuse, and release KafkaMessageSenders") {
+		val poolSize = 2
+		val broker = "localhost:9092"
+
+		for {
+			pool <- KafkaMessageSenderPool.make[IO](poolSize, mockKafkaMessageSenderFactory)
+			sender1 <- pool.get(broker)
+			_ <- pool.release(broker, sender1)
+			sender2 <- pool.get(broker)
+			_ <- pool.release(broker, sender2)
+			sender3 <- pool.get(broker)
+			sender4 <- pool.get(broker)
+			_ <- pool.release(broker, sender3)
+			_ <- pool.release(broker, sender4)
+			poolSizeAfterTest <- pool.size
+		} yield {
+			sender1 shouldEqual sender2
+			sender3 shouldEqual sender4
+			poolSizeAfterTest shouldEqual 1
+		}
+	}
+}

--- a/src/test/scala/com/mungos/filewatcher/utils/ConfigUtilsSpec.scala
+++ b/src/test/scala/com/mungos/filewatcher/utils/ConfigUtilsSpec.scala
@@ -1,0 +1,59 @@
+package com.mungos.filewatcher.utils
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import com.mungos.filewatcher.{ConsoleDestination, FileConfig, HttpDestination, KafkaDestination, WatcherConfig}
+import org.scalatest.funsuite.AsyncFunSuite
+import org.scalatest.matchers.should.Matchers
+import com.mungos.filewatcher.utils.configUtils.*
+
+import scala.concurrent.duration.*
+
+class ConfigUtilsSpec extends AsyncFunSuite with Matchers with AsyncIOSpec {
+
+	test("Config reader should correctly decode a valid WatcherConfig JSON") {
+		val configJson =
+			"""
+				|{
+				|  "fileConfigs": [
+				|    {
+				|      "file": "file1.txt",
+				|      "interval": "1s",
+				|      "destination": {
+				|        "type": "http",
+				|        "uri": "https://example.com/api"
+				|      }
+				|    },
+				|    {
+				|      "file": "file2.txt",
+				|      "interval": "2s",
+				|      "destination": {
+				|        "type": "kafka",
+				|        "brokers": "localhost:9092",
+				|        "topic": "my-topic"
+				|      }
+				|    },
+				|    {
+				|      "file": "file3.txt",
+				|      "interval": "1s",
+				|      "destination": {
+				|        "type": "console"
+				|      }
+				|    }
+				|  ]
+				|}
+				|""".stripMargin
+
+		val expectedResult = WatcherConfig(
+			List(
+				FileConfig("file1.txt", 1.seconds, HttpDestination("https://example.com/api")),
+				FileConfig("file2.txt", 2.seconds, KafkaDestination("localhost:9092", "my-topic")),
+				FileConfig("file3.txt", 1.seconds, ConsoleDestination)
+			)
+		)
+
+		val actualResult: IO[WatcherConfig] = decodeWatcherConfig(configJson)
+
+		actualResult.asserting(_ shouldEqual expectedResult)
+	}
+}


### PR DESCRIPTION
This PR introduces an HttpSender to handle sending new lines from the watched file. Additionally, it includes an implementation of KafkaMessageSender, which is yet to be tested. The changes improve the flexibility and reliability of the file watcher, allowing it to send messages via HTTP and Kafka seamlessly. Further testing and validation will be carried out to ensure the robustness and correctness of these new features.